### PR TITLE
Migrate patch from 3.2.7 to 3.3.7

### DIFF
--- a/cmake/FindAdolc.cmake
+++ b/cmake/FindAdolc.cmake
@@ -14,7 +14,7 @@ find_path(ADOLC_INCLUDES
 find_library(ADOLC_LIBRARIES adolc PATHS $ENV{ADOLCDIR} ${LIB_INSTALL_DIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(ADOLC DEFAULT_MSG
+find_package_handle_standard_args(Adolc DEFAULT_MSG
                                   ADOLC_INCLUDES ADOLC_LIBRARIES)
 
 mark_as_advanced(ADOLC_INCLUDES ADOLC_LIBRARIES)

--- a/cmake/FindCholmod.cmake
+++ b/cmake/FindCholmod.cmake
@@ -83,7 +83,7 @@ if(CHOLMOD_LIBRARIES)
 endif(CHOLMOD_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CHOLMOD DEFAULT_MSG
+find_package_handle_standard_args(Cholmod DEFAULT_MSG
                                   CHOLMOD_INCLUDES CHOLMOD_LIBRARIES)
 
 mark_as_advanced(CHOLMOD_INCLUDES CHOLMOD_LIBRARIES AMD_LIBRARY COLAMD_LIBRARY SUITESPARSE_LIBRARY CAMD_LIBRARY CCOLAMD_LIBRARY CHOLMOD_METIS_LIBRARY)

--- a/cmake/FindGoogleHash.cmake
+++ b/cmake/FindGoogleHash.cmake
@@ -18,6 +18,6 @@ if(GOOGLEHASH_INCLUDES)
 endif(GOOGLEHASH_INCLUDES)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GOOGLEHASH DEFAULT_MSG GOOGLEHASH_INCLUDES GOOGLEHASH_COMPILE)
+find_package_handle_standard_args(Googlehash DEFAULT_MSG GOOGLEHASH_INCLUDES GOOGLEHASH_COMPILE)
 
 mark_as_advanced(GOOGLEHASH_INCLUDES)

--- a/cmake/FindMetis.cmake
+++ b/cmake/FindMetis.cmake
@@ -256,7 +256,7 @@ mark_as_advanced(METIS_DIR_FOUND)
 # check that METIS has been found
 # ---------------------------------
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(METIS DEFAULT_MSG
+find_package_handle_standard_args(Metis DEFAULT_MSG
   METIS_LIBRARIES
   METIS_WORKS)
 #

--- a/cmake/FindPastix.cmake
+++ b/cmake/FindPastix.cmake
@@ -699,6 +699,6 @@ mark_as_advanced(PASTIX_DIR_FOUND)
 # check that PASTIX has been found
 # ---------------------------------
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PASTIX DEFAULT_MSG
+find_package_handle_standard_args(Pastix DEFAULT_MSG
   PASTIX_LIBRARIES
   PASTIX_WORKS)

--- a/cmake/FindScotch.cmake
+++ b/cmake/FindScotch.cmake
@@ -361,7 +361,7 @@ set(CMAKE_REQUIRED_INCLUDES "")
 # check that SCOTCH has been found
 # ---------------------------------
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SCOTCH DEFAULT_MSG
+find_package_handle_standard_args(Scotch DEFAULT_MSG
   SCOTCH_LIBRARIES
   SCOTCH_WORKS)
 #

--- a/cmake/FindSuperLU.cmake
+++ b/cmake/FindSuperLU.cmake
@@ -90,7 +90,7 @@ endif()
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(SUPERLU
+find_package_handle_standard_args(SuperLU
                                   REQUIRED_VARS SUPERLU_INCLUDES SUPERLU_LIBRARIES SUPERLU_VERSION_OK
                                   VERSION_VAR SUPERLU_VERSION_VAR)
 

--- a/cmake/FindUmfpack.cmake
+++ b/cmake/FindUmfpack.cmake
@@ -47,7 +47,7 @@ if(UMFPACK_LIBRARIES)
 endif(UMFPACK_LIBRARIES)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(UMFPACK DEFAULT_MSG
+find_package_handle_standard_args(Umfpack DEFAULT_MSG
                                   UMFPACK_INCLUDES UMFPACK_LIBRARIES)
 
 mark_as_advanced(UMFPACK_INCLUDES UMFPACK_LIBRARIES AMD_LIBRARY COLAMD_LIBRARY CHOLMOD_LIBRARY SUITESPARSE_LIBRARY)


### PR DESCRIPTION
I looked at using 3.3.9.  It looks like the patch will be more or less the same again. The only reason I didn't just move the patch to 3.3.9 is because there are a lot of changes from 3.3.7 to 3.3.9, and I am not sure when I am going to have time to test 3.3.9... I am going to try and get to it today, but depends on the two other bugs I need to get fixed.